### PR TITLE
removing python dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Judo is an easy-to-use Command Line Interface (CLI) integration testing framewor
 | Build Dependencies                |           |
 | --------------------------------- | --------- |
 | [node](https://nodejs.org/en/)    | \>=8.7.0  |
-| [python](https://www.python.org/) | \>=2.7.10 |
 
 ## Installation
 


### PR DESCRIPTION
for #9 

removing python from README since it's not actually a dependency. verified by installing in a docker container that didn't have python and it executes as expected
