### PR TITLE
34: Adding support for JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ The Judo framework interacts with CLIs and provides assertions against the outpu
 # point to a "test scenario" file
 judo <file>.yml
 
-# or point to a "test suite" directory of "test suite" yaml files
+# point to a "test scenario" JSON file
+judo <file>.json
+
+# or point to a "test suite" directory of "test suite" yaml files. See options section for the optional flag to support JSON files.
 judo <directory>
 ```
 
@@ -84,6 +87,8 @@ judo <directory>
 - `--timeout <n>` : sets a max time in milliseconds that a run step can take before being considered a timeout. ex (`--timeout 1500`)
 
 - `--junitreport | -j` : writes the test results to a file called `junit.xml` in the current working directory. This report is in xUnit format.
+
+- `--includejsonfiles | -ij` : include `.json` test files in the test directory along with `.yml` files.
 
 ### Creating Tests with YAML files
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,54 @@ In this example, a new child process will be spawned which runs all of the comma
 
 After that it will spawn another child process and run the `echo "hi!"` command assertion described in the first example.
 
+### Complete JSON Example
+
+This is a more complete example using JSON and similar to the above YML example, running multiple commands and responding to the `stdin` when appropriate:
+
+```js
+{
+  "run": {
+    "someCommand": {
+      "prerequisiteCwd": "/Users/efrancis/devel/DEVGRU/judo/temp/",
+      "prerequisites": [
+        "echo \"this command will run before the command being tested\"",
+        "echo \"this will too\"",
+        "git clone <some repo>",
+        "cd <some-repo>"
+      ],
+      "command": "git checkout -b \"some-feature\"",
+      "cwd": "/Users/hansolo/test",
+      "when": [
+        {
+          "What do you fly?": "Millenium Falcon"
+        },
+        {
+          "Did you shoot first?": "y"
+        }
+      ],
+      "expectCode": 0,
+      "outputContains": [
+        "This string should be in the complete stdout/stderr output",
+        "/This is a regex[!]+/g/"
+      ],
+      "outputDoesntContain": [
+        "This string should NOT be in the complete stdout/stderr output"
+      ]
+    },
+    "anotherCommand": {
+      "command": "echo \"hi!\"",
+      "expectCode": 0,
+      "outputContains": [
+        "hi!"
+      ],
+      "outputDoesntContain": [
+        "bye!"
+      ]
+    }
+  }
+}
+```
+
 ## How it Works
 
 Judo operates in the following order:

--- a/src/judo.js
+++ b/src/judo.js
@@ -33,6 +33,9 @@ const run = async () => {
     if (flag === '--junitreport' || flag === '-j') {
       options.junitReport = true;
     }
+    if (flag === '--includejsonfiles' || flag === '-ij') {
+      options.includeJSONFiles = true;
+    }
   });
 
   if (!yamlFilePath) {
@@ -54,7 +57,7 @@ const run = async () => {
   } else if (isDirectory(yamlFilePath)) {
     // if argument is a directory, run against all files in that dir and subdirs recursively
     const allStepFiles = listFilesRecursively(yamlFilePath).filter(
-      file => file.indexOf('.yml') !== -1
+      file => file.indexOf('.yml') !== -1 || (options.includeJSONFiles && file.indexOf('.json') !== -1)
     );
     const numStepFiles = allStepFiles.length;
 

--- a/src/judo.test.js
+++ b/src/judo.test.js
@@ -485,6 +485,77 @@ describe('judo', () => {
           expect.stringContaining('FAILED "goodbyeWorld"')
         );
       });
+      it('runs two step files if process arguments is a directory path containing two JSON files, runs the two steps in those files, and passes if all pass', async () => {
+        const stepFilePath = 'tests/my-test.xml';
+        mockLogger();
+        global.process.exit = jest.fn();
+        global.process.argv = ['node', 'judo.js', stepFilePath, '--includejsonfiles'];
+        fileUtilModule.isFile = jest.fn(() => false);
+        fileUtilModule.isDirectory = jest.fn(() => true);
+        fileUtilModule.listFilesRecursively = () => [
+          'filea.json',
+          'somdir/fileb.json'
+        ];
+        yaml.safeLoad = jest
+          .fn()
+          .mockImplementationOnce(path => mockStepFileSingle)
+          .mockImplementationOnce(path => mockStepFileTwo);
+
+        executorModule.executePrerequisites = jest.fn(async () => {});
+        executorModule.execute = jest
+          .fn()
+          .mockImplementationOnce(async () => helloWorldMockExecuteOutput)
+          .mockImplementationOnce(async () => helloWorldAgainMockExecuteOutput)
+          .mockImplementationOnce(async () => goodbyeWorldMockExecuteOutput);
+
+        await run();
+
+        expect(executorModule.executePrerequisites).toHaveBeenCalledTimes(2);
+        expect(executorModule.executePrerequisites).toHaveBeenCalledWith({
+          prerequisites: ['echo "this is a prereq command"'],
+          cwd: undefined
+        });
+        expect(executorModule.execute).toHaveBeenCalledTimes(3); // helloWorld, helloWorldAgain, goodbyeWorld
+        expect(executorModule.execute).toHaveBeenCalledWith(
+          'echo',
+          ['hello world!'],
+          {
+            argsString: '"hello world!"',
+            cwd: undefined,
+            when: [],
+            timeout: 120000
+          }
+        );
+        expect(executorModule.execute).toHaveBeenCalledWith(
+          'echo',
+          ['hello again world!'],
+          {
+            argsString: '"hello again world!"',
+            cwd: undefined,
+            when: [],
+            timeout: 120000
+          }
+        );
+        expect(executorModule.execute).toHaveBeenCalledWith(
+          'echo',
+          ['goodbye world!'],
+          {
+            argsString: '"goodbye world!"',
+            cwd: undefined,
+            when: [],
+            timeout: 120000
+          }
+        );
+        expect(loggerModule.logger.success).toHaveBeenCalledWith(
+          expect.stringContaining('PASSED "helloWorld"')
+        );
+        expect(loggerModule.logger.success).toHaveBeenCalledWith(
+          expect.stringContaining('PASSED "helloWorldAgain"')
+        );
+        expect(loggerModule.logger.error).toHaveBeenCalledWith(
+          expect.stringContaining('FAILED "goodbyeWorld"')
+        );
+      });
       it('logs error and exits with code 1 if error occurs running step file', async () => {
         const stepFilePath = 'tests/my-test.xml';
         mockLogger();

--- a/test-examples/simple-test-suite/hello-world.json
+++ b/test-examples/simple-test-suite/hello-world.json
@@ -1,0 +1,14 @@
+{
+    "run": {
+      "helloWorld": {
+        "command": "echo \"hi!\"",
+        "expectCode": 0,
+        "outputContains": [
+          "hi!"
+        ],
+        "outputDoesntContain": [
+          "bye!"
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
- [x] Does all of your new or changed code have unit tests?
- [x] Is overall unit test statement coverage still above 85%?
- [x] Is code style linting passing with `npm run lint`?
- [x] Is the related GitHub issue number included in your branch name? ex branch name: `fix/12-some-bug`
- [x] Is the related GitHub issue number included in your pull request title? example PR title: "12 - Fixes some bug"
- [x] Is documentation still up to date after your change?


At times I have tests in JSON files, adding support for JSON files out of the box would surely be helpful. Changes at the YAML level are not necessary as the [js-yaml schema supports JSON in the core schema itself](https://github.com/nodeca/js-yaml/blob/master/lib/js-yaml/schema/core.js#L16).