### PR TITLE
43 - folder-scoped reusable variables 

### DIFF
--- a/src/judo.test.js
+++ b/src/judo.test.js
@@ -10,15 +10,15 @@ jest.mock('js-yaml');
 jest.mock('fs');
 jest.mock('child_process');
 
-const STEP_FILE_PATH = 'tests/my-test.xml',
-  PATH_1 = 'path1',
-  NAME_1 = 'name1',
-  PATH_2 = 'path2',
-  NAME_2 = 'name2',
-  PREREQ_COMMAND = 'echo "this is a prereq command"',
-  NODE = 'node',
-  JUDO_JS = 'judo.js',
-  GOODBYE = 'goodbye';
+const STEP_FILE_PATH = 'tests/my-test.xml';
+const PATH_1 = 'path1';
+const NAME_1 = 'name1';
+const PATH_2 = 'path2';
+const NAME_2 = 'name2';
+const PREREQ_COMMAND = 'echo "this is a prereq command"';
+const NODE = 'node';
+const JUDO_JS = 'judo.js';
+const GOODBYE = 'goodbye';
 
 const mockStepResultsPassed = [
   new StepResult({
@@ -150,7 +150,6 @@ const mockLogger = () => {
 };
 
 describe('judo', () => {
-
   beforeEach(() => {
     mockLogger();
     global.process.exit = jest.fn();


### PR DESCRIPTION
This PR tackles [issue 43](https://github.com/intuit/judo/issues/43). 
Moved all the strings that are reused multiple time in the `judo.test.js` file into it's own constants at the top of the file. Also moved the redundent pieces of code into beforeEach blocks.

- [ x] Does all of your new or changed code have unit tests?
- [x ] Is overall unit test statement coverage still above 85%?
- [x ] Is code style linting passing with `npm run lint`?
- [x ] Is the related GitHub issue number included in your branch name? ex branch name: `fix/12-some-bug`
- [x ] Is the related GitHub issue number included in your pull request title? example PR title: "12 - Fixes some bug"
- [ x] Is documentation still up to date after your change?