### PR TITLE
43 - file-scoped reusable variables for test file

### DIFF
--- a/src/executor.test.js
+++ b/src/executor.test.js
@@ -67,13 +67,14 @@ const mockChildSpawnWorked = (writeMock, options = { timeout: 600 }) => {
 };
 
 describe('executor', () => {
-  describe('executePrerequisites', () => {
-    beforeEach(() => {
-      mockLogger();
-      mockExecWorked();
-    });
+  beforeEach(() => {
+    mockLogger();
+  });
 
+  describe('executePrerequisites', () => {
     it('combines commands into one by chaining them with &&, and runs them in the specified cwd', async () => {
+      mockExecWorked();
+
       let err;
       let res;
 
@@ -93,6 +94,8 @@ describe('executor', () => {
       });
     });
     it('logs output from stdout and stderr, and logs when complete', async () => {
+      mockExecWorked();
+
       let err;
       let res;
 
@@ -115,6 +118,8 @@ describe('executor', () => {
     });
 
     it('rejects if commands exit with non-zero code', async () => {
+      mockExecFailed();
+
       let err;
       let res;
 
@@ -131,6 +136,8 @@ describe('executor', () => {
       expect(err).toBeInstanceOf(Error);
     });
     it('resolves if commands exit with zero code', async () => {
+      mockExecWorked();
+
       let err;
       let res;
 

--- a/src/executor.test.js
+++ b/src/executor.test.js
@@ -6,7 +6,6 @@ const STDOUT = 'stdout';
 const STDERR = 'stderr';
 const CMD1 = 'cmd1';
 const CMD2 = 'cmd2';
-const ECHO = 'echo';
 const SOME_DIR = 'some/dir';
 const PIPE = 'pipe';
 
@@ -163,7 +162,7 @@ describe('executor', () => {
 
       mockChildSpawnWorked(writeMock);
 
-      const cmd = ECHO;
+      const cmd = 'echo';
       const args = ['hello', 'world!'];
       const opts = {
         // argsString: '"hello world!"',
@@ -189,7 +188,7 @@ describe('executor', () => {
 
       mockChildSpawnWorked(writeMock);
 
-      const cmd = ECHO;
+      const cmd = 'echo';
       const args = ['hello world!', '1>&2'];
       const opts = {
         argsString: '"hello world!"',
@@ -218,7 +217,7 @@ describe('executor', () => {
       mockChildSpawnWorked(writeMock);
 
       try {
-        res = await execute(ECHO, ['hello world!'], {
+        res = await execute('echo', ['hello world!'], {
           argsString: '"hello world!"',
           cwd: undefined,
           when: [
@@ -250,7 +249,7 @@ describe('executor', () => {
       let res;
 
       try {
-        res = await execute(ECHO, ['hello world!'], {
+        res = await execute('echo', ['hello world!'], {
           argsString: '"hello world!"',
           cwd: undefined,
           when: [
@@ -281,7 +280,7 @@ describe('executor', () => {
       mockChildSpawnWorked(writeMock, { timeout: 500 });
 
       try {
-        res = await execute(ECHO, ['hello world!'], {
+        res = await execute('echo', ['hello world!'], {
           argsString: '"hello world!"',
           cwd: undefined,
           when: [],


### PR DESCRIPTION
Related to #43 
Extracted file-scoped reusable variables for `executor.test.js`. Moved repeated code into beforeEach block. 

- [x] Does all of your new or changed code have unit tests?
- [x] Is overall unit test statement coverage still above 85%?
- [x] Is code style linting passing with `npm run lint`?
- [x] Is the related GitHub issue number included in your branch name? ex branch name: `fix/12-some-bug`
- [x] Is the related GitHub issue number included in your pull request title? example PR title: "12 - Fixes some bug"
- [x] Is documentation still up to date after your change?